### PR TITLE
Improve recursive variant example with indirect containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,25 +62,26 @@ struct json_value {
         bool operator==(const null_t&) const = default;
     };
 
-    using array_t  = std::vector<indirect<json_value>>;
-    using object_t = std::map<std::string, indirect<json_value>>;
+    using array_t  = indirect<std::vector<json_value>>;
+    using object_t = indirect<std::map<std::string, json_value>>;
 
     std::variant<null_t, bool, double, std::string, array_t, object_t> data;
 
     json_value() : data(null_t{}) {}
     json_value(double d) : data(d) {}
+    json_value(const char* s) : data(std::string(s)) {}
     json_value(std::string s) : data(std::move(s)) {}
-    json_value(array_t a) : data(std::move(a)) {}
-    json_value(object_t o) : data(std::move(o)) {}
+    json_value(std::vector<json_value> a) : data(array_t{std::in_place, std::move(a)}) {}
+    json_value(std::map<std::string, json_value> o) : data(object_t{std::in_place, std::move(o)}) {}
 
     bool operator==(const json_value&) const = default;
 };
 
-json_value person(json_value::object_t{
-    {"name", indirect<json_value>(std::string("Alice"))},
-    {"scores", indirect<json_value>(json_value::array_t{
-        indirect<json_value>(10.0),
-        indirect<json_value>(20.0),
+json_value person(std::map<std::string, json_value>{
+    {"name", json_value("Alice")},
+    {"scores", json_value(std::vector<json_value>{
+        json_value(10.0),
+        json_value(20.0),
     })},
 });
 

--- a/cmake/features.cmake
+++ b/cmake/features.cmake
@@ -13,10 +13,7 @@ int main() {}
 "
         HAVE_CONCEPTS
     )
-    set(${result_var}
-        ${HAVE_CONCEPTS}
-        PARENT_SCOPE
-    )
+    set(${result_var} ${HAVE_CONCEPTS} PARENT_SCOPE)
 endfunction()
 
 function(beman_indirect_check_three_way_comparison result_var)
@@ -34,10 +31,7 @@ int main() {
 "
         HAVE_THREE_WAY
     )
-    set(${result_var}
-        ${HAVE_THREE_WAY}
-        PARENT_SCOPE
-    )
+    set(${result_var} ${HAVE_THREE_WAY} PARENT_SCOPE)
 endfunction()
 
 function(beman_indirect_check_constexpr_destructor result_var)
@@ -50,10 +44,7 @@ int main() { S s; }
 "
         HAVE_CONSTEXPR_DTOR
     )
-    set(${result_var}
-        ${HAVE_CONSTEXPR_DTOR}
-        PARENT_SCOPE
-    )
+    set(${result_var} ${HAVE_CONSTEXPR_DTOR} PARENT_SCOPE)
 endfunction()
 
 function(beman_indirect_check_no_unique_address result_var)
@@ -69,8 +60,5 @@ int main() {}
 "
         HAVE_NO_UNIQUE_ADDRESS
     )
-    set(${result_var}
-        ${HAVE_NO_UNIQUE_ADDRESS}
-        PARENT_SCOPE
-    )
+    set(${result_var} ${HAVE_NO_UNIQUE_ADDRESS} PARENT_SCOPE)
 endfunction()

--- a/examples/recursive_variant.cpp
+++ b/examples/recursive_variant.cpp
@@ -27,8 +27,8 @@ struct json_value {
         friend bool operator!=(const null_t&, const null_t&) { return false; }
     };
 
-    using array_t  = std::vector<indirect<json_value>>;
-    using object_t = std::map<std::string, indirect<json_value>>;
+    using array_t  = indirect<std::vector<json_value>>;
+    using object_t = indirect<std::map<std::string, json_value>>;
 
     std::variant<null_t, bool, double, std::string, array_t, object_t> data;
 
@@ -38,8 +38,8 @@ struct json_value {
     json_value(double d) : data(d) {}
     json_value(const char* s) : data(std::string(s)) {}
     json_value(std::string s) : data(std::move(s)) {}
-    json_value(array_t a) : data(std::move(a)) {}
-    json_value(object_t o) : data(std::move(o)) {}
+    json_value(std::vector<json_value> a) : data(array_t{std::in_place, std::move(a)}) {}
+    json_value(std::map<std::string, json_value> o) : data(object_t{std::in_place, std::move(o)}) {}
 
     friend bool operator==(const json_value& lhs, const json_value& rhs) { return lhs.data == rhs.data; }
     friend bool operator!=(const json_value& lhs, const json_value& rhs) { return !(lhs == rhs); }
@@ -59,19 +59,19 @@ std::ostream& operator<<(std::ostream& os, const json_value& v) {
                 os << '"' << val << '"';
             } else if constexpr (std::is_same_v<V, json_value::array_t>) {
                 os << '[';
-                for (std::size_t i = 0; i < val.size(); ++i) {
+                for (std::size_t i = 0; i < val->size(); ++i) {
                     if (i > 0)
                         os << ", ";
-                    os << *val[i];
+                    os << (*val)[i];
                 }
                 os << ']';
             } else if constexpr (std::is_same_v<V, json_value::object_t>) {
                 os << '{';
                 bool first = true;
-                for (const auto& [k, v] : val) {
+                for (const auto& [k, v] : *val) {
                     if (!first)
                         os << ", ";
-                    os << '"' << k << "\": " << *v;
+                    os << '"' << k << "\": " << v;
                     first = false;
                 }
                 os << '}';
@@ -84,15 +84,15 @@ std::ostream& operator<<(std::ostream& os, const json_value& v) {
 int main() {
     // Build a small JSON structure:
     //   {"name": "Alice", "scores": [10, 20, 30], "active": true}
-    json_value person(json_value::object_t{
-        {"name", indirect<json_value>("Alice")},
+    json_value person(std::map<std::string, json_value>{
+        {"name", json_value("Alice")},
         {"scores",
-         indirect<json_value>(json_value::array_t{
-             indirect<json_value>(10.0),
-             indirect<json_value>(20.0),
-             indirect<json_value>(30.0),
+         json_value(std::vector<json_value>{
+             json_value(10.0),
+             json_value(20.0),
+             json_value(30.0),
          })},
-        {"active", indirect<json_value>(true)},
+        {"active", json_value(true)},
     });
 
     std::cout << "person: " << person << "\n";


### PR DESCRIPTION
## Summary
- Use `indirect<vector<json_value>>` and `indirect<map<string, json_value>>` instead of wrapping each element individually, reducing allocations and improving cache locality.
- Hide `indirect` from the public API by accepting plain `std::vector` and `std::map` in constructors.
- Also includes gersemi formatting fixes in `cmake/features.cmake`.

## Test plan
- [ ] Verify C++17 and C++20 builds pass
- [ ] Run `examples/recursive_variant` and confirm correct output

🤖 Generated with [Claude Code](https://claude.com/claude-code)