### PR TITLE
Remove redundant GTest::gtest link from test targets

### DIFF
--- a/tests/beman/indirect/CMakeLists.txt
+++ b/tests/beman/indirect/CMakeLists.txt
@@ -6,14 +6,14 @@ add_executable(beman.indirect.tests.indirect)
 target_sources(beman.indirect.tests.indirect PRIVATE indirect.test.cpp)
 target_link_libraries(
     beman.indirect.tests.indirect
-    PRIVATE beman::indirect GTest::gtest GTest::gtest_main
+    PRIVATE beman::indirect GTest::gtest_main
 )
 
 add_executable(beman.indirect.tests.polymorphic)
 target_sources(beman.indirect.tests.polymorphic PRIVATE polymorphic.test.cpp)
 target_link_libraries(
     beman.indirect.tests.polymorphic
-    PRIVATE beman::indirect GTest::gtest GTest::gtest_main
+    PRIVATE beman::indirect GTest::gtest_main
 )
 
 include(GoogleTest)


### PR DESCRIPTION
## Summary
- Remove explicit `GTest::gtest` from test target link libraries since `GTest::gtest_main` already links it transitively.

## Test plan
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)