### PR TITLE
Enable beman-tidy v0.5.1 in default mode

### DIFF
--- a/.beman-tidy.yaml
+++ b/.beman-tidy.yaml
@@ -7,4 +7,4 @@
 disabled_rules:
     # None
 ignored_paths:
-    # None
+    - infra/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,11 +40,12 @@ repos:
     hooks:
       - id: codespell
 
-    # Beman Standard checking via beman-tidy
+  # Beman Standard checking via beman-tidy
   - repo: https://github.com/bemanproject/beman-tidy
     rev: v0.5.1
     hooks:
-    - id: beman-tidy
+      - id: beman-tidy
+        args: [".", "--verbose"]
 
 
 exclude: 'cookiecutter/|infra/|port/'


### PR DESCRIPTION
Issue: https://github.com/bemanproject/beman-tidy/issues/330

Enable beman-tidy in default mode (requirements only) with v0.5.1.

## Test plan
- [x] pre-commit run beman-tidy --all-files passes